### PR TITLE
update to 23.01

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,23 @@
-FROM alpine:latest
+FROM alpine:3.18
 MAINTAINER Dan Bryant (daniel.bryant@linux.com)
 
-# add variable VERSION for 7zip build number, The default value here is 2201
-ARG VERSION=2201
+# add variable VERSION for 7zip build number, The default value here is 2301
+ARG VERSION=2301
 ENV TZ=Europe/London
 
 # install all the Linux build dependencies
-RUN apk add --no-cache alpine-sdk git patch wget clang make build-base musl-dev
-RUN apk add --no-cache clang-dev gcc lld
-RUN apk add --no-cache llvm curl libarchive-tools xz
+# after clang-14 we get errors
+RUN apk add --no-cache alpine-sdk git patch wget clang14 make build-base musl-dev
+RUN apk add --no-cache clang14-dev gcc lld
+RUN apk add --no-cache llvm14 curl libarchive-tools xz
+
+# create convenience symlinks for clang
+RUN ln -s /usr/bin/clang-14 /usr/local/bin/clang
+RUN ln -s /usr/bin/clang++-14 /usr/local/bin/clang++
 
 # we will try to compile UASM on Linux
 RUN mkdir /usr/local/src && cd /usr/local/src && git clone --branch v2.56.2 https://github.com/Terraspace/UASM.git
-RUN cd /usr/local/src/UASM && make CC="clang -fcommon -static -std=c99" -f gccLinux64.mak
+RUN cd /usr/local/src/UASM && make CC="clang -fcommon -static -std=gnu99 -Wno-error=int-conversion" -f gccLinux64.mak
 RUN cp /usr/local/src/UASM/GccUnixR/uasm /usr/local/bin/uasm
 
 # 7-zip source is now available in Tar XZ format
@@ -23,11 +28,13 @@ RUN rm -f /tmp/7z${VERSION}-src.tar.xz
 # MUSL doesn't support pthread_attr_setaffinity_np so we have to disable affinity
 # we also have to amend the warnings so we don't trip over "disabled expansion of recursive macro"
 # we need a small patch to ensure UASM doesn't try to align the stack in any assembler functions - this mimics expected asmc behaviour
-RUN cd /usr/local/src/7z${VERSION} && sed -i -e '1i\OPTION FRAMEPRESERVEFLAGS:ON\nOPTION PROLOGUE:NONE\nOPTION EPILOGUE:NONE' Asm/x86/*.asm
+RUN cd /usr/local/src/7z${VERSION} && sed -i -e '1i\OPTION FRAMEPRESERVEFLAGS:ON\nOPTION PROLOGUE:NONE\nOPTION EPILOGUE:NONE' Asm/x86/7zAsm.asm
 
 # create the Clang version
-RUN cd /usr/local/src/7z${VERSION}/CPP/7zip/Bundles/Alone2 && make CFLAGS_BASE_LIST="-c -static -D_7ZIP_AFFINITY_DISABLE=1" MY_ASM=uasm MY_ARCH="-static" CFLAGS_WARN_WALL="-Wall -Wextra" -f ../../cmpl_clang_x64.mak
+RUN cd /usr/local/src/7z${VERSION}/CPP/7zip/Bundles/Alone2 && make CFLAGS_BASE_LIST="-c -static -D_7ZIP_AFFINITY_DISABLE=1 -DZ7_AFFINITY_DISABLE=1 -D_GNU_SOURCE=1" MY_ASM=uasm MY_ARCH="-static" CFLAGS_WARN_WALL="-Wall -Wextra" -f ../../cmpl_clang_x64.mak
+RUN strip /usr/local/src/7z${VERSION}/CPP/7zip/Bundles/Alone2/b/c_x64/7zz
 RUN mv /usr/local/src/7z${VERSION}/CPP/7zip/Bundles/Alone2/b/c_x64/7zz /usr/local/bin/7zz
+RUN cp /usr/local/bin/7zz /opt/7zz
 
 # clean up the source files for our binaries
 RUN rm -rf /usr/local/src/UASM

--- a/README.md
+++ b/README.md
@@ -5,28 +5,28 @@
 
 ## Usage
 
-### Install
-
 You can build the `7zip_static` Docker container from source, during the container's build it will create the UASM and 7-Zip binaries as statically linked executables. 
 
-In the case of UASM it will compile the executable with Clang as `/usr/local/bin/uasm`. In the case of 7-Zip it will compile the executable with Clang as `/usr/local/bin/7zz`.
+In the case of UASM it will compile the executable with Clang as `/usr/local/bin/uasm`. In the case of 7-Zip it will compile the executable with Clang as `/usr/local/bin/7zz` and copy it to `/opt/7zz`.
 
-#### To create the Docker container from scratch and copy the binaries to the current working directory.
+## Building the 7-zip Binaries
 
-##### first, view https://www.7-zip.org/history.txt and get 7-zip latest build number,example:
+### Getting the Latest Version of 7-Zip
+First, view https://www.7-zip.org/history.txt and get 7-zip's latest build number, for example:
 ```
 HISTORY of the 7-Zip
 --------------------
 
-21.04 beta     2021-11-02
+23.01          2023-06-20
 -------------------------
 ```
-you can get the latest build number is 21.04, so variable VERSION=2104, Important without decimal point!
+You can see the latest build number is 23.01, so we need to set the variable like so `VERSION=2301`. Importantly we should set it without the decimal point!
 
-##### second, run the commands below:
+### Creating the Binaries
+Just run the commands below to build 7-zip as a static executable and copy the binary to the current folder. Make sure to update the `VERSION` variable as appropriate.
 ```
 git clone https://github.com/justdan96/7zip_static.git
 cd 7zip_static
-docker build --build-arg VERSION=2104 -t 7zip_static . 2>&1 | tee build.log
-docker run -it --rm -v $(pwd):/workdir -w="/workdir" 7zip_static sh -c "cp /usr/local/bin/* /workdir"
+docker build --build-arg VERSION=2301 -t 7zip_static . 2>&1 | tee build.log
+docker run -it --rm -v $(pwd):/workdir -w="/workdir" 7zip_static sh -c "cp /opt/* /workdir"
 ```


### PR DESCRIPTION
It took quite a long time for me to figure out all of the issues I was experiencing. Turns out that versions above Clang 14 cause compilation issues with both UASM and 7-zip. For now I have pinned the versions of Alpine and Clang to known  releases that definitely work. 

I've also made some changes so that hopefully in the future binaries can be produced automatically.